### PR TITLE
Better colors for the transportPaye and fraisInscriptionPaye icons

### DIFF
--- a/src/components/Enrollments.tsx
+++ b/src/components/Enrollments.tsx
@@ -91,8 +91,8 @@ function Enrollments({ dias, currentYear }: any) {
                     <BanknotesIcon
                       className={`w-6 h-6 lg:w-8 lg:h-8 ${
                         dia.fraisInscriptionPaye
-                          ? "text-yellow-500"
-                          : `text-gray-400 ${dia.anneeAcademiqueId == currentYear && "hover:text-green-500"}`
+                          ? "text-green-500"
+                          : `text-red-500 ${dia.anneeAcademiqueId == currentYear && "hover:text-green-500"}`
                       }`}
                     />
                     <div className="hidden group-hover:block absolute min-w-fit p-2 bg-gray-200 rounded text-xs">
@@ -114,8 +114,8 @@ function Enrollments({ dias, currentYear }: any) {
                     <MapIcon
                       className={`w-6 h-6 lg:w-8 lg:h-8 ${
                         dia.transportPaye
-                          ? "text-yellow-500"
-                          : `text-gray-400 ${dia.anneeAcademiqueId == currentYear && "hover:text-green-500"}`
+                          ? "text-green-500"
+                          : `text-red-500 ${dia.anneeAcademiqueId == currentYear && "hover:text-green-500"}`
                       }`}
                     />
                     <div className="hidden group-hover:block absolute min-w-fit p-2 bg-gray-200 rounded text-xs">


### PR DESCRIPTION
If the user hasn’t paid the _transportPaye_ or _fraisInscriptionPaye_, the icon color is red instead of gray. If they have paid, the icon is green instead of yellow.

![Screenshot from 2025-01-14 16-55-56](https://github.com/user-attachments/assets/8e169736-6644-4ecc-9935-170d0152b450)

![Screenshot from 2025-01-14 16-56-17](https://github.com/user-attachments/assets/7c6221f1-0c07-439b-95f5-a1364dd450a4)

_Suggested By:_ @ramymoze 