### PR TITLE
Better handling for empty exam notes in ModuleCard / Using the word 'N/A' instead of 'Empty'

### DIFF
--- a/src/app/panel/[year]/page.tsx
+++ b/src/app/panel/[year]/page.tsx
@@ -322,7 +322,7 @@ const renderSemesterResultItem = (result: any) => {
                       <p className="text-gray-800">
                         <span className="font-semibold">Average: </span>
                         <span className={`${mcAverageClass} font-bold`}>
-                          {mc.moyenneGenerale ? mc.moyenneGenerale : "Empty"}
+                          {mc.moyenneGenerale ? mc.moyenneGenerale : "N/A"}
                         </span>
                       </p>
                     </div>

--- a/src/components/ExamNotes.tsx
+++ b/src/components/ExamNotes.tsx
@@ -33,7 +33,9 @@ function ModuleCard({ module }: { module: Module }) {
     >
       <h4 className="font-semibold flex-1">{module.mcLibelleFr}</h4>
       <p className="font-bold ml-2 text-gray-700">
-        {module.noteExamen !== null ? module.noteExamen : "Empty"}
+        {module.noteExamen !== null && module.noteExamen !== undefined
+          ? module.noteExamen
+          : "N/A"}
       </p>
     </div>
   )

--- a/src/components/NormalNotes.tsx
+++ b/src/components/NormalNotes.tsx
@@ -33,7 +33,7 @@ function NormalNotes({ normal }: NormalNotesProps) {
             <p className="font-semibold mr-4">{rattachementMcMcLibelleFr}</p>
             <div className="flex gap-4 ml-2">
               <p className="font-bold text-gray-700">
-                {noteValue == null ? "Empty" : noteValue}
+                {noteValue == null ? "N/A" : noteValue}
               </p>
               <p className="font-bold">{apCode}</p>
             </div>


### PR DESCRIPTION
Before:
![Screenshot from 2025-01-18 12-07-35](https://github.com/user-attachments/assets/ff792190-defe-4696-8b64-77b35afa928e)

After:
![Screenshot from 2025-01-18 12-11-27](https://github.com/user-attachments/assets/8b6b4afc-4a16-470e-8c28-9fbadd596bc7)
