### PR TITLE
A more reasonable timeout duration for server-side requests / using the user ID in cache keys instead of the token hash

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,7 @@
 PROGRES_API = "https://progres.mesrs.dz/api/infos"
 CURRENT_HOST = "https://webetu.univ-annaba.dz"
 CURRENT_YEAR = 22
-SERVER_TIMEOUT = 5000
+SERVER_TIMEOUT = 10000
 DIA_SECURITY = true
 NEXT_PUBLIC_TIMEOUT = 10000
 NEXT_PUBLIC_EPAIEMENT_TRANSPORT = "https://progres.mesrs.dz/epaiement/epaiementT.xhtml"

--- a/src/utils/api/helpers.ts
+++ b/src/utils/api/helpers.ts
@@ -13,7 +13,6 @@ export function getCookieData() {
   const cookieStore = cookies()
   const token = cookieStore.get("token")?.value || ""
   const uuid = cookieStore.get("uuid")?.value as string
-  const tokenHash = createHash("md5").update(token).digest("hex")
 
   if (token.length > 500) throw new Error("Token is too large!")
 
@@ -35,7 +34,7 @@ export function getCookieData() {
   if (Number.isNaN(EtabId) || EtabId.toString().length > 20)
     throw new Error("Invalid EtabId!")
 
-  return { token, user, uuid, tokenHash, EtabId }
+  return { token, user, uuid, EtabId }
 }
 
 export async function fetchData(link: string, token: string) {

--- a/src/utils/api/panel.ts
+++ b/src/utils/api/panel.ts
@@ -3,9 +3,9 @@ import { longCache, shortCache } from "@/utils/cache"
 import { fetchData, getCookieData } from "./helpers"
 
 export const getDias = async () => {
-  const { token, user, uuid, tokenHash } = getCookieData()
+  const { token, user, uuid } = getCookieData()
 
-  const cacheKey = `dias-${tokenHash}`
+  const cacheKey = `dias-${user}`
   const cachedData = longCache.get(cacheKey)
 
   if (cachedData) {
@@ -29,9 +29,9 @@ export const getDias = async () => {
 }
 
 export const getNormalNotes = async (id: number) => {
-  const { token, user, tokenHash } = getCookieData()
+  const { token, user } = getCookieData()
 
-  const cacheKey = `notes-${id}-${tokenHash}`
+  const cacheKey = `notes-${id}-${user}`
   const cachedData = shortCache.get(cacheKey)
 
   if (cachedData) {
@@ -77,9 +77,9 @@ export const getNormalNotes = async (id: number) => {
 }
 
 export const getExamsNotes = async (id: number) => {
-  const { token, user, tokenHash } = getCookieData()
+  const { token, user } = getCookieData()
 
-  const cacheKey = `exams-${id}-${tokenHash}`
+  const cacheKey = `exams-${id}-${user}`
   const cachedData = shortCache.get(cacheKey)
 
   if (cachedData) {
@@ -137,9 +137,9 @@ export const getExamsNotes = async (id: number) => {
 }
 
 export const getSemesterResults = async (id: number) => {
-  const { token, user, uuid, tokenHash } = getCookieData()
+  const { token, user, uuid } = getCookieData()
 
-  const cacheKey = `semesters-transcripts-${id}-${tokenHash}`
+  const cacheKey = `semesters-transcripts-${id}-${user}`
   const cachedData = shortCache.get(cacheKey)
 
   if (cachedData) {
@@ -189,9 +189,9 @@ export const getSemesterResults = async (id: number) => {
 }
 
 export const getYearTranscript = async (id: number) => {
-  const { token, user, uuid, tokenHash } = getCookieData()
+  const { token, user, uuid } = getCookieData()
 
-  const cacheKey = `year-transcript-${id}-${tokenHash}`
+  const cacheKey = `year-transcript-${id}-${user}`
   const cachedData = shortCache.get(cacheKey)
 
   if (cachedData) {
@@ -218,9 +218,9 @@ export const getYearTranscript = async (id: number) => {
 }
 
 export const getGroup = async (id: number) => {
-  const { token, user, tokenHash } = getCookieData()
+  const { token, user } = getCookieData()
 
-  const cacheKey = `group-${id}-${tokenHash}`
+  const cacheKey = `group-${id}-${user}`
   const cachedData = shortCache.get(cacheKey)
 
   if (cachedData) {
@@ -269,9 +269,9 @@ export const getGroup = async (id: number) => {
 }
 
 export const getTimeTable = async (id: number) => {
-  const { token, user, tokenHash } = getCookieData()
+  const { token, user } = getCookieData()
 
-  const cacheKey = `timetable-${id}-${tokenHash}`
+  const cacheKey = `timetable-${id}-${user}`
   const cachedData = shortCache.get(cacheKey)
 
   if (cachedData) {

--- a/src/utils/api/profile.ts
+++ b/src/utils/api/profile.ts
@@ -4,7 +4,7 @@ import { fetchData, getCookieData } from "./helpers"
 import { ApiResponseType, ProfileDataType } from "@/utils/types"
 
 export async function getProfileData() {
-  const { token, user, uuid, tokenHash } = getCookieData()
+  const { token, user, uuid } = getCookieData()
 
   let response: ApiResponseType = {
     success: false,
@@ -12,7 +12,7 @@ export async function getProfileData() {
     error: undefined,
   }
 
-  const cacheKey = `profile-${tokenHash}`
+  const cacheKey = `profile-${user}`
   const cachedData = longCache.get(cacheKey) as ProfileDataType
 
   if (cachedData) {
@@ -61,9 +61,9 @@ export async function getProfileData() {
 }
 
 export const getImage = async () => {
-  const { token, user, uuid, tokenHash } = getCookieData()
+  const { token, user, uuid } = getCookieData()
 
-  const cacheKey = `image-${tokenHash}`
+  const cacheKey = `image-${user}`
   const cachedData = longCache.get(cacheKey)
 
   if (cachedData) {


### PR DESCRIPTION
- A 10-second timeout duration is more reasonable compared to 5 seconds

- Using the token hash in cache keys means that every time the user logs in, the cache is bypassed, resulting in unnecessary HTTP requests being sent to Progress. To address this, we now use the user ID instead